### PR TITLE
Review changes 

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -52,10 +52,12 @@ add_library(bssl-compat STATIC
   source/BIO_new_bio_pair.cc
   source/BIO_pending.cc
   source/BIO_printf.cc
+  source/BIO_read.cc
   source/BIO_read_asn1.c
   source/BIO_snprintf.cc
   source/BIO_vfree.cc
   source/BIO_wpending.c
+  source/BIO_write.cc
   source/BN_cmp_word.cc
   source/BN_bn2hex.cc
   source/BN_bin2bn.cc
@@ -353,7 +355,6 @@ target_add_bssl_function(bssl-compat
   BIO_new_socket
   BIO_new_mem_buf
   BIO_puts
-  BIO_read
   BIO_read_filename
   BIO_reset
   BIO_get_mem_data
@@ -372,7 +373,6 @@ target_add_bssl_function(bssl-compat
   BIO_shutdown_wr
   BIO_up_ref
   BIO_free_all
-  BIO_write
   BN_add_word
   BN_add_word
   BN_add_word

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -77,7 +77,6 @@ add_library(bssl-compat STATIC
   source/EVP_DigestVerifyFinal.cc
   source/EVP_DigestSignFinal.cc
   source/EVP_get_digestbyname.cc
-  source/EVP_MD_CTX_init.cc
   source/EVP_MD_CTX_move.cc
   source/EVP_parse_public_key.cc
   source/EVP_PKEY_get0_EC_KEY.cc
@@ -440,6 +439,7 @@ target_add_bssl_function(bssl-compat
   EVP_MD_CTX_copy_ex
   EVP_MD_CTX_create
   EVP_MD_CTX_free
+  EVP_MD_CTX_init
   EVP_MD_CTX_new
   EVP_MD_CTX_destroy
   EVP_MD_nid

--- a/bssl-compat/patch/source/ssl/ssl_test.cc.patch
+++ b/bssl-compat/patch/source/ssl/ssl_test.cc.patch
@@ -1,5 +1,5 @@
---- a/source/ssl/ssl_test.cc	2025-08-28 11:09:06.338911419 +0200
-+++ b/source/ssl/ssl_test.cc	2025-08-28 17:49:04.355472491 +0200
+--- a/source/ssl/ssl_test.cc
++++ b/source/ssl/ssl_test.cc
 @@ -23,7 +23,6 @@
  #include <utility>
  #include <vector>
@@ -138,3 +138,16 @@
  }
  
  TEST_P(SSLVersionTest, RetainOnlySHA256OfCerts) {
+@@ -4228,7 +4264,11 @@
+   ASSERT_TRUE(CreateClientAndServer(&client_, &server_, client_ctx_.get(),
+                                     server_ctx_.get()));
+   // Before the handshake, |SSL_version| reports some placeholder value.
+-  const uint16_t placeholder = is_dtls() ? DTLS1_2_VERSION : TLS1_2_VERSION;
++#ifdef BSSL_COMPAT // Default versions are different when running on OpenSSL
++  const uint16_t placeholder = is_dtls() ? DTLS1_2_VERSION : TLS1_3_VERSION;
++#else
++  const uint16_t placeholder = is_dtls() ? DTLS1_3_VERSION : TLS1_3_VERSION;
++#endif
+   EXPECT_EQ(SSL_version(client_.get()), placeholder);
+   EXPECT_EQ(SSL_version(server_.get()), placeholder);
+ 

--- a/bssl-compat/source/BIO_read.cc
+++ b/bssl-compat/source/BIO_read.cc
@@ -1,0 +1,15 @@
+#include <openssl/bio.h>
+#include <ossl.h>
+
+
+int BIO_read(BIO *bio, void *data, int len) {
+  int result = ossl.ossl_BIO_read(bio, data, len);
+  if (result == -1) {
+    unsigned long err = ossl.ossl_ERR_peek_last_error();
+    if (ossl_ERR_GET_LIB(err) == ossl_ERR_LIB_BIO &&
+        ossl_ERR_GET_REASON(err) == ossl_BIO_R_UNINITIALIZED) {
+          result = -2;
+    }
+  }
+  return result;
+}

--- a/bssl-compat/source/BIO_write.cc
+++ b/bssl-compat/source/BIO_write.cc
@@ -1,0 +1,15 @@
+#include <openssl/bio.h>
+#include <ossl.h>
+
+
+int BIO_write(BIO *bio, const void *data, int len) {
+  int result = ossl.ossl_BIO_write(bio, data, len);
+  if (result == -1) {
+    unsigned long err = ossl.ossl_ERR_peek_last_error();
+    if (ossl_ERR_GET_LIB(err) == ossl_ERR_LIB_BIO &&
+        ossl_ERR_GET_REASON(err) == ossl_BIO_R_UNINITIALIZED) {
+          result = -2;
+    }
+  }
+  return result;
+}

--- a/bssl-compat/source/EVP_MD_CTX_init.cc
+++ b/bssl-compat/source/EVP_MD_CTX_init.cc
@@ -1,7 +1,0 @@
-#include <openssl/digest.h>
-#include <ossl.h>
-
-
-extern "C" void EVP_MD_CTX_init(EVP_MD_CTX *ctx) {
-  ossl.ossl_EVP_MD_CTX_init(ctx);
-}

--- a/bssl-compat/tools/generate.h.sh
+++ b/bssl-compat/tools/generate.h.sh
@@ -38,24 +38,15 @@ mkdir -p "$(dirname "$CMAKE_CURRENT_BINARY_DIR/$DST_FILE")"
 
 
 #
-# Set useful variables
-# =================================
-#
-PATCH_SCRIPT="$PATCH_DIR/$DST_FILE.sh"
-GEN_APPLIED_SCRIPT="$CMAKE_CURRENT_BINARY_DIR/$DST_FILE.1.applied.script"
-cp "$SRC_DIR/$SRC_FILE" "$GEN_APPLIED_SCRIPT"
-
-
-#
 # Apply patch file from $PATCH_DIR
 # ================================
 #
 PATCH_FILE="$PATCH_DIR/$DST_FILE.patch"
-GEN_APPLIED_PATCH="$CMAKE_CURRENT_BINARY_DIR/$DST_FILE.2.applied.patch"
+GEN_APPLIED_PATCH="$CMAKE_CURRENT_BINARY_DIR/$DST_FILE.1.applied.patch"
 if [ -f "$PATCH_FILE" ]; then
-    patch -s -f "$GEN_APPLIED_SCRIPT" "$PATCH_FILE" -o "$GEN_APPLIED_PATCH"
+    patch -s -f "$SRC_DIR/$SRC_FILE" "$PATCH_FILE" -o "$GEN_APPLIED_PATCH"
 else
-    cp "$GEN_APPLIED_SCRIPT" "$GEN_APPLIED_PATCH"
+    cp "$SRC_DIR/$SRC_FILE" "$GEN_APPLIED_PATCH"
 fi
 
 
@@ -63,14 +54,17 @@ fi
 # Apply script file from $PATCH_DIR
 # =================================
 #
+PATCH_SCRIPT="$PATCH_DIR/$DST_FILE.sh"
+GEN_APPLIED_SCRIPT="$CMAKE_CURRENT_BINARY_DIR/$DST_FILE.2.applied.script"
+cp "$GEN_APPLIED_PATCH" "$GEN_APPLIED_SCRIPT"
 if [ -f "$PATCH_SCRIPT" ]; then
-    PATH="$(dirname "$0"):$PATH" "$PATCH_SCRIPT" "$GEN_APPLIED_PATCH"
+    PATH="$(dirname "$0"):$PATH" "$PATCH_SCRIPT" "$GEN_APPLIED_SCRIPT"
 else # Comment out the whole file contents
-    "$(dirname "$0")/uncomment.sh" "$GEN_APPLIED_PATCH" --comment
+    "$(dirname "$0")/uncomment.sh" "$GEN_APPLIED_SCRIPT" --comment
 fi
 
 #
 # Copy result to the destination
 # ==============================
 #
-cp "$GEN_APPLIED_PATCH" "$CMAKE_CURRENT_BINARY_DIR/$DST_FILE"
+cp "$GEN_APPLIED_SCRIPT" "$CMAKE_CURRENT_BINARY_DIR/$DST_FILE"


### PR DESCRIPTION
- The namining of the `<x>.1.applied.patch` and `<x>.2.applied.script` intermediate files now reflects the order in which they are produced.
- Removed hand written `EVP_MD_CTX_init()`
- Fixed `BIO_read/write()` return code for calls on uninitialised `BIO`
- Fixed default versions in the WithVersion/SSLVersionTest.Version/* tests
